### PR TITLE
Changed the model from “gpt-4” to “gpt-4o-mini”

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ bot.on('chat', async (username, message) => {
     const response = await axios.post(
       openaiApiUrl,
       {
-        model: 'gpt-4',
+        model: 'gpt-4o-mini',
         messages: context,
         temperature: 0.5,
         max_tokens: 300,


### PR DESCRIPTION
The gpt-4o-mini would be much cheaper than gpt-4 in the context of our use case. No perfomance will change for our use case